### PR TITLE
fix(gcp): Check the interval is at least 5m

### DIFF
--- a/pkg/providers/gcp/scraper.go
+++ b/pkg/providers/gcp/scraper.go
@@ -111,6 +111,9 @@ func (s *Scraper) scrape(ctx context.Context) error {
 	s.Client.Refresh(ctx, *s.Project)
 
 	interval := config.AppConfig().Interval
+	if interval < 5*time.Minute {
+		return fmt.Errorf("error interval for GCP needs to be atleast 5m. It is: %+v", interval)
+	}
 
 	instances, err := s.Client.GetMetricsForInstances(ctx, *s.Project, interval.String())
 


### PR DESCRIPTION
GCP requires an interval of at least 5m to query for metrics. If the interval is less than that error out of the GCP scraper.