### PR TITLE
Fix(AWS): Remove non-running instances from state

### DIFF
--- a/pkg/providers/aws/ec2.go
+++ b/pkg/providers/aws/ec2.go
@@ -45,9 +45,15 @@ func (c *Client) updateInstancesMap(region string, res []types.Reservation) {
 			instance := r.Instances[index]
 
 			id := aws.ToString(instance.InstanceId)
-			vCPUs := aws.ToInt32(instance.CpuOptions.CoreCount) * aws.ToInt32(instance.CpuOptions.ThreadsPerCore)
-
 			key := util.Key(region, ec2Service, id)
+
+			// Remove non-running instances
+			if instance.State.Name != types.InstanceStateNameRunning {
+				delete(c.instancesMap, key)
+				continue
+			}
+
+			vCPUs := aws.ToInt32(instance.CpuOptions.CoreCount) * aws.ToInt32(instance.CpuOptions.ThreadsPerCore)
 			c.instancesMap[key] = &v1.Instance{
 				Name:     id,
 				Provider: provider,

--- a/pkg/providers/aws/ec2_test.go
+++ b/pkg/providers/aws/ec2_test.go
@@ -1,17 +1,87 @@
 package amazon
 
-// TODO write unit tests that don't make API calls
-//  func TestEc2InstanceListing(t *testing.T) {
-//	  ctx := context.Background()
-//	  // Pass an empty provider config so that it loads the default credentials
-//	  cfg, err := buildAWSConfig(ctx, &config.Account{}, nil)
-//	  assert.NotNil(t, cfg)
-//	  assert.Nil(t, err)
-//
-//	  // Init the ec2 client
-//	  ec2Client := NewEC2Client(&cfg)
-//	  assert.NotNil(t, ec2Client)
-//
-//	  err = ec2Client.Refresh(ctx, "eu-north-1")
-//	  assert.Nil(t, err)
-//  }
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	v1 "github.com/re-cinq/aether/pkg/types/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test the updateInstancesMap logic. The state of the
+// instancesMap is shared among all the runs of the test
+func TestUpdateInstancesMap(t *testing.T) {
+	c := Client{
+		instancesMap: make(map[string]*v1.Instance),
+	}
+
+	// A test up of the []types.Reservation type that contains
+	// EC2 instance information
+	res := []types.Reservation{
+		{
+			Instances: []types.Instance{
+				{
+					InstanceId:        aws.String("foo123"),
+					InstanceType:      types.InstanceTypeA1Medium,
+					InstanceLifecycle: types.InstanceLifecycleTypeScheduled,
+					CpuOptions: &types.CpuOptions{
+						CoreCount:      aws.Int32(4),
+						ThreadsPerCore: aws.Int32(2),
+					},
+					State: &types.InstanceState{
+						Name: types.InstanceStateNameRunning,
+						Code: aws.Int32(16),
+					},
+				},
+				{
+					InstanceId:        aws.String("bar456"),
+					InstanceType:      types.InstanceTypeT3Micro,
+					InstanceLifecycle: types.InstanceLifecycleTypeScheduled,
+					CpuOptions: &types.CpuOptions{
+						CoreCount:      aws.Int32(4),
+						ThreadsPerCore: aws.Int32(2),
+					},
+					State: &types.InstanceState{
+						Name: types.InstanceStateNameTerminated,
+						Code: aws.Int32(48),
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("Running instance added to instancesMap", func(t *testing.T) {
+		c.updateInstancesMap("fakeRegion", res)
+
+		// check that the running instance is added to instancesMap
+		_, exists := c.instancesMap["fakeRegion-AWS/EC2-foo123"]
+		assert.True(t, exists)
+	})
+
+	t.Run("Terminated instance not added to instancesMap", func(t *testing.T) {
+		c.updateInstancesMap("fakeRegion", res)
+
+		// check that the terminated instance is not added to instancesMap
+		_, exists := c.instancesMap["fakeRegion-AWS/EC2-bar456"]
+		assert.False(t, exists)
+	})
+
+	t.Run("Instance in map changed to terminated state, remove from map", func(t *testing.T) {
+		// check that the running instance still exists in the map
+		_, exists := c.instancesMap["fakeRegion-AWS/EC2-foo123"]
+		assert.True(t, exists)
+
+		// modify the state of that instance to be "stopping"
+		res[0].Instances[0].State = &types.InstanceState{
+			Name: types.InstanceStateNameStopping,
+			Code: aws.Int32(64),
+		}
+
+		c.updateInstancesMap("fakeRegion", res)
+
+		// check that the instance was deleted from the instancesMap
+		_, exists = c.instancesMap["fakeRegion-AWS/EC2-foo123"]
+		assert.False(t, exists)
+	})
+}


### PR DESCRIPTION
Fixes #68 by checking the state of the instance, before adding it to the instancesMap, and if it is not running it deletes it from the map.