### PR TITLE
feat(memory): Add memory calculations for AWS

### DIFF
--- a/pkg/calculator/handler.go
+++ b/pkg/calculator/handler.go
@@ -128,11 +128,12 @@ func (c *CalculatorHandler) handleEvent(e *bus.Event) {
 	}
 
 	if d, ok := awsInstances[instance.Kind]; ok {
-		params.wattage = d.PkgWatt
+		params.powerCPU = d.PkgWatt
+		params.powerRAM = d.RAMWatt
 		params.vCPU = float64(d.VCPU)
 		params.embodiedFactor = d.EmbodiedHourlyGCO2e
 	} else {
-		params.wattage = []data.Wattage{
+		params.powerCPU = []data.Wattage{
 			{
 				Percentage: 0,
 				Wattage:    specs.MinWatts,


### PR DESCRIPTION
Closes: #74
Add memory calculations for AWS. These calculations are based on the wattRam data collected by TEADs based on similar machine types using RAPL. This does not yet exist for GCP.