### PR TITLE
feat: Store energy consumption along with emissions

### DIFF
--- a/pkg/calculator/handler.go
+++ b/pkg/calculator/handler.go
@@ -132,14 +132,12 @@ func (c *CalculatorHandler) handleEvent(e *bus.Event) {
 	for _, v := range metrics {
 		params.metric = &v
 
-		o, err := operationalEmissions(ctx, interval, params)
+		err := operationalEmissions(ctx, interval, params)
 		if err != nil {
 			c.logger.Error("error calulating emissions", "type", v.Name, "error", err)
 			continue
 		}
-
 		// update the instance metrics
-		params.metric.Emissions = v1.NewResourceEmission(o, v1.GCO2eq)
 		metrics.Upsert(params.metric)
 	}
 

--- a/pkg/types/v1/metric.go
+++ b/pkg/types/v1/metric.go
@@ -37,6 +37,12 @@ type Metric struct {
 	// - Gb: in case of Ram
 	Unit ResourceUnit
 
+	// The energy consumption calculated
+	// for the metric. This is then multiplied
+	// by the pue and grid coefficient to get
+	// the Emissions data
+	Energy float64
+
 	// Emissions at a specific point in time
 	Emissions ResourceEmissions
 


### PR DESCRIPTION
Closes #78
Store the calculated energy consumption for each metric in the Metric data type. This allows it to be stored in the instance and sent to the exporters as a possible datapoint along with carbon emission equivalents and embodied emissions.