### PR TITLE
Feat: Memory fallback methods for metrics

### DIFF
--- a/docs/methodologies.md
+++ b/docs/methodologies.md
@@ -231,6 +231,12 @@ As a reminder, this is only for CPU. To get the total CO₂e emissions for a ser
 
 <br>
 
+## Calculating Memory VM Carbon Emissions
+
+
+
+<br>
+
 ## Additional work
 
 <br>
@@ -240,7 +246,7 @@ We have been working on creating a similar dataset implementation for GCE instan
 
 <br>
 
-#### Memory, Storage, Networking
+#### Storage, Networking
 We are implementing a similar equation for calculating memory, but using the RAMWatt readings as the wattage variables. We will do a similar write up on that next. Then move onto storage and networking.
 
 <br>

--- a/pkg/calculator/calculator_test.go
+++ b/pkg/calculator/calculator_test.go
@@ -20,43 +20,45 @@ func params() *parameters {
 		pue:    1.2,
 		metric: m,
 		// using t3.micro AWS instance as default
-		powerCPU: []data.Wattage{
-			{
-				Percentage: 0,
-				Wattage:    1.21,
+		factors: &data.Instance{
+			PkgWatt: []data.Wattage{
+				{
+					Percentage: 0,
+					Wattage:    1.21,
+				},
+				{
+					Percentage: 10,
+					Wattage:    3.05,
+				},
+				{
+					Percentage: 50,
+					Wattage:    7.16,
+				},
+				{
+					Percentage: 100,
+					Wattage:    9.96,
+				},
 			},
-			{
-				Percentage: 10,
-				Wattage:    3.05,
+			RAMWatt: []data.Wattage{
+				{
+					Percentage: 0,
+					Wattage:    0.15,
+				},
+				{
+					Percentage: 10,
+					Wattage:    0.24,
+				},
+				{
+					Percentage: 50,
+					Wattage:    0.62,
+				},
+				{
+					Percentage: 100,
+					Wattage:    1.00,
+				},
 			},
-			{
-				Percentage: 50,
-				Wattage:    7.16,
-			},
-			{
-				Percentage: 100,
-				Wattage:    9.96,
-			},
+			VCPU: 2.0,
 		},
-		powerRAM: []data.Wattage{
-			{
-				Percentage: 0,
-				Wattage:    0.15,
-			},
-			{
-				Percentage: 10,
-				Wattage:    0.24,
-			},
-			{
-				Percentage: 50,
-				Wattage:    0.62,
-			},
-			{
-				Percentage: 100,
-				Wattage:    1.00,
-			},
-		},
-		vCPU:           2,
 		embodiedFactor: 1000,
 	}
 }
@@ -89,7 +91,7 @@ func TestCalculateCPU(t *testing.T) {
 		func() *testcase {
 			// vCPUs not set in params, but set in metric
 			p := params()
-			p.vCPU = 0
+			p.factors.VCPU = 0
 			p.metric.UnitAmount = 2
 			p.metric.Unit = v1.VCPU
 			return &testcase{
@@ -106,7 +108,7 @@ func TestCalculateCPU(t *testing.T) {
 		func() *testcase {
 			// vCPUs not set
 			p := params()
-			p.vCPU = 0
+			p.factors.VCPU = 0
 			return &testcase{
 				name:     "vCPU not set",
 				interval: 5 * time.Minute,
@@ -155,7 +157,7 @@ func TestCalculateCPU(t *testing.T) {
 		func() *testcase {
 			// calculate with 4 vCPUs
 			p := params()
-			p.vCPU = 4
+			p.factors.VCPU = 4
 			return &testcase{
 				name:     "4 vCPU",
 				interval: 5 * time.Minute,
@@ -338,7 +340,7 @@ func TestCalculateMemory(t *testing.T) {
 		func() *testcase {
 			// fail: powerRAM wattage not set
 			p := params()
-			p.powerRAM = []data.Wattage{}
+			p.factors.RAMWatt = []data.Wattage{}
 			return &testcase{
 				name:      "fail: wattage RAM data not set",
 				params:    p,

--- a/pkg/calculator/handler.go
+++ b/pkg/calculator/handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"reflect"
 
 	"gopkg.in/yaml.v2"
 
@@ -16,13 +17,15 @@ import (
 	data "github.com/re-cinq/emissions-data/pkg/types/v2"
 )
 
-var awsInstances map[string]data.Instance
+var instanceData map[string]data.Instance
 
 // AWS, GCP and Azure have increased their server lifespan to 6 years (2024)
 // https://sustainability.aboutamazon.com/products-services/the-cloud?energyType=true
 // https://www.theregister.com/2024/01/31/alphabet_q4_2023/
 // https://www.theregister.com/2022/08/02/microsoft_server_life_extension/
 const serverLifespan = 6
+
+var emptyWattage = []data.Wattage{{0, 0}, {10, 0}, {50, 0}, {100, 0}}
 
 // CalculatorHandler is used to handle events when metrics have been collected
 type CalculatorHandler struct {
@@ -41,9 +44,14 @@ func NewHandler(ctx context.Context, b *bus.Bus) *CalculatorHandler {
 		return nil
 	}
 
-	awsInstances, err = getProviderEC2EmissionFactors(v1.AWS)
+	err = getProviderEC2EmissionFactors(v1.AWS)
 	if err != nil {
-		logger.Error("unable to get v2 Emission Factors, falling back to v1", "error", err)
+		logger.Error("unable to get v2 Emission Factors", "error", err, "provider", v1.AWS)
+	}
+
+	err = getProviderEC2EmissionFactors(v1.GCP)
+	if err != nil {
+		logger.Error("unable to get v2 Emission Factors", "error", err, "provider", v1.GCP)
 	}
 
 	return &CalculatorHandler{
@@ -119,13 +127,15 @@ func (c *CalculatorHandler) handleEvent(e *bus.Event) {
 		pue:  factor.AveragePUE,
 	}
 
-	if d, ok := awsInstances[instance.Kind]; ok {
-		params.powerCPU = d.PkgWatt
-		params.powerRAM = d.RAMWatt
-		params.vCPU = float64(d.VCPU)
-		params.embodiedFactor = d.EmbodiedHourlyGCO2e
-	} else {
-		params.powerCPU = []data.Wattage{
+	if d, ok := instanceData[instance.Kind]; ok {
+		params.factors = &d
+	}
+
+	// fallback to use spec power min and max watt values.
+	// this is less accurate and a place holder until a
+	// different solution is implemented.
+	if reflect.DeepEqual(params.factors.PkgWatt, emptyWattage) {
+		params.factors.PkgWatt = []data.Wattage{
 			{
 				Percentage: 0,
 				Wattage:    specs.MinWatts,
@@ -135,6 +145,9 @@ func (c *CalculatorHandler) handleEvent(e *bus.Event) {
 				Wattage:    specs.MaxWatts,
 			},
 		}
+	}
+
+	if params.embodiedFactor == 0 {
 		params.embodiedFactor = hourlyEmbodiedEmissions(&specs)
 	}
 
@@ -186,21 +199,21 @@ func hourlyEmbodiedEmissions(e *factors.Embodied) float64 {
 		(e.VCPU / e.TotalVCPU)
 }
 
-func getProviderEC2EmissionFactors(provider v1.Provider) (map[string]data.Instance, error) {
+func getProviderEC2EmissionFactors(provider v1.Provider) error {
 	url := "https://raw.githubusercontent.com/re-cinq/emissions-data/main/data/v2/%s-instances.yaml"
 	u := fmt.Sprintf(url, provider)
 
 	r, err := http.Get(u)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer r.Body.Close()
 
 	d := yaml.NewDecoder(r.Body)
-	err = d.Decode(&awsInstances)
+	err = d.Decode(&instanceData)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return awsInstances, nil
+	return nil
 }

--- a/pkg/providers/gcp/instance.go
+++ b/pkg/providers/gcp/instance.go
@@ -100,7 +100,7 @@ func (c *Client) memoryMetrics(ctx context.Context, project, query string) error
 		m.Unit = v1.GB
 		m.ResourceType = v1.Memory
 		// convert Bytes to GB
-		m.Usage = float64(resp.GetPointData()[0].GetValues()[0].GetInt64Value()) / 1024 / 1024 / 1024
+		m.UnitAmount = float64(resp.GetPointData()[0].GetValues()[0].GetInt64Value()) / 1024 / 1024 / 1024
 		m.Labels = v1.Labels{
 			"id":           instanceID,
 			"name":         instanceName,


### PR DESCRIPTION
Closes: 81
* Depending on the metrics collected from the MQL query, set the utilization for calculating emissions.
* Update the methodologies doc with how the metric information is calculated.
* Tests for memory metrics