### PR TITLE
fix: check for not exists error

### DIFF
--- a/pkg/plugin/exporter.go
+++ b/pkg/plugin/exporter.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -110,6 +111,9 @@ func (e *ExportPluginSystem) Load(ctx context.Context) error {
 
 	// Open the plugin directory.
 	files, err := os.ReadDir(e.Dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/source.go
+++ b/pkg/plugin/source.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -138,6 +139,9 @@ func (s *SourcePluginSystem) Load(ctx context.Context) error {
 
 	// Open the plugin directory.
 	files, err := os.ReadDir(s.Dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When trying to load plugins this change now checks if we get a not exists error and just returns, so as to handle the case where no plugins are set

fixes: https://github.com/re-cinq/aether/issues/104