### PR TITLE
chore: set sensible defaults

### DIFF
--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -14,16 +14,7 @@ image:
 # this secret will be volumed under `/etc/secrets`
 secretName: ""
 
-config:
-  logLevel: "info"
-  api:
-    address: 0.0.0.0
-    port: 80
-  
-  providersConfig:
-    scrapingInterval: 5m
-  
-  providers: {}
+config: {}
 
 imagePullSecrets: []
 nameOverride: ""
@@ -53,7 +44,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
 ingress:
   enabled: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,9 @@ func InitConfig(ctx context.Context) {
 	viper.SetDefault("cache.expiry", "3600m")
 	viper.SetDefault("plugins.exporterDir", "/plugins/exporters")
 	viper.SetDefault("plugins.sourceDir", "/plugins/sources")
+	viper.SetDefault("api.address", "0.0.0.0")
+	viper.SetDefault("api.port", "8080")
+	viper.SetDefault("providersConfig.scrapingInterval", "5m")
 
 	// Find and read the config file
 	err := viper.ReadInConfig()


### PR DESCRIPTION
In a lot of cases configuration wont really change if we set sensible and it greatly simplifies deploying aether