### PR TITLE
Chore: bump chart aether version

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1-alpha.8"
+appVersion: "0.0.1-alpha.9"


### PR DESCRIPTION
By default have the kepler working version of aether installed