### PR TITLE
fix: plugin logging

### DIFF
--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -74,7 +74,7 @@ func main() {
 	setLogLevel(lvl, config.AppConfig().LogLevel)
 
 	// Load exporter plugins
-	logger.Info("loading plugins")
+	logger.Info("loading exporters", "dir", config.AppConfig().Plugins.ExporterDir)
 	pluginsystem := &plugin.ExportPluginSystem{
 		Dir: config.AppConfig().Plugins.ExporterDir,
 	}
@@ -84,9 +84,11 @@ func main() {
 		logger.Error("failed to load exporter plugin system", "error", err)
 		os.Exit(1)
 	}
+	logger.Info("finished loading exporters", "output",
+		fmt.Sprintf("%d loaded", len(pluginsystem.Plugins)))
 
 	// Load source plugins
-	logger.Info("loading sources")
+	logger.Info("loading sources", "dir", config.AppConfig().Plugins.SourceDir)
 	sourcePluginSystem := &plugin.SourcePluginSystem{
 		Dir: config.AppConfig().Plugins.SourceDir,
 	}
@@ -96,6 +98,8 @@ func main() {
 		logger.Error("failed to load exporter plugin system", "error", err)
 		os.Exit(1)
 	}
+	logger.Info("finished loading sources", "output",
+		fmt.Sprintf("%d loaded", len(sourcePluginSystem.Plugins)))
 
 	// Init the application bus
 	b := bus.New()

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-yaml/yaml v2.1.0+incompatible
 	github.com/google/go-cmp v0.6.0
 	github.com/gorilla/mux v1.8.1
+	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-plugin v1.6.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/common v0.45.0
@@ -68,7 +69,6 @@ require (
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
-	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/pkg/plugin/exporter.go
+++ b/pkg/plugin/exporter.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
@@ -133,6 +134,12 @@ func (e *ExportPluginSystem) Load(ctx context.Context) error {
 			},
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 			Cmd:              exec.Command(pluginPath),
+			Logger: hclog.New(&hclog.LoggerOptions{
+				Name:       "exporter",
+				Output:     os.Stdout,
+				Level:      hclog.Debug,
+				JSONFormat: true,
+			}),
 		})
 
 		// Start the plugin process.

--- a/pkg/plugin/source.go
+++ b/pkg/plugin/source.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc"
 
@@ -162,6 +163,12 @@ func (s *SourcePluginSystem) Load(ctx context.Context) error {
 			},
 			AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 			Cmd:              exec.Command(pluginPath),
+			Logger: hclog.New(&hclog.LoggerOptions{
+				Name:       "source",
+				Output:     os.Stdout,
+				Level:      hclog.Debug,
+				JSONFormat: true,
+			}),
 		})
 
 		// Start the plugin process.


### PR DESCRIPTION
With go-plugin it is hard to debug the plugins, therefore this change should allow for more robust logging. We should in the future make this more confiurable and aligined with the internal logging system